### PR TITLE
update pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ streamlit-tags = "*"
 streamlit-extras = "*"
 black = "*"
 torch = "*"
+colorama = {version="*",sys_platform ="== 'win32'"}
 
 [dev-packages]
 


### PR DESCRIPTION
Added a small change to the Pipfile, this updates Pipfile.lock during "pipenv install" so Windows users can launch the app without dependency errors and the need for Docker. I haven't performed any extensive testing, but it seems to work for the most part. 