### PR TITLE
Switch to cache_resource for Document Index

### DIFF
--- a/utils/llama_index.py
+++ b/utils/llama_index.py
@@ -111,7 +111,7 @@ def load_documents(data_dir: str):
 ###################################
 
 
-@st.cache_data(show_spinner=False)
+@st.cache_resource(show_spinner=False)
 def create_index(_documents):
     """
     Creates an index from the provided documents and service context.


### PR DESCRIPTION
This PR solves the issue of a missing `_model` in the Index after loading it from cache.

It seems that it is better to use another caching decorator.

As described in https://docs.streamlit.io/develop/concepts/architecture/caching
> `st.cache_resource` is the recommended way to cache global resources like ML models or database connections – unserializable objects that you don't want to load multiple times. Using it, you can share these resources across all reruns and sessions of an app without copying or duplication. Note that any mutations to the cached return value directly mutate the object in the cache (more details below).

Closes #53