### PR TITLE
Fixes application crash when models not found

### DIFF
--- a/components/tabs/settings.py
+++ b/components/tabs/settings.py
@@ -22,8 +22,10 @@ def settings():
         )
         st.selectbox(
             "Model",
-            st.session_state["ollama_models"],
+            st.session_state["ollama_models"] if isinstance(st.session_state["ollama_models"],list) else [],
             key="selected_model",
+            disabled= not isinstance(st.session_state["ollama_models"],list),
+            placeholder= "Select Model" if isinstance(st.session_state["ollama_models"],list) else "No Models Available",
         )
         st.button(
             "Refresh",

--- a/components/tabs/settings.py
+++ b/components/tabs/settings.py
@@ -22,10 +22,10 @@ def settings():
         )
         st.selectbox(
             "Model",
-            st.session_state["ollama_models"] if isinstance(st.session_state["ollama_models"],list) else [],
+            st.session_state["ollama_models"],
             key="selected_model",
-            disabled= not isinstance(st.session_state["ollama_models"],list),
-            placeholder= "Select Model" if isinstance(st.session_state["ollama_models"],list) else "No Models Available",
+            disabled= len(st.session_state["ollama_models"])==0,
+            placeholder= "Select Model" if len(st.session_state["ollama_models"])>0 else "No Models Available",
         )
         st.button(
             "Refresh",

--- a/utils/ollama.py
+++ b/utils/ollama.py
@@ -88,8 +88,7 @@ def get_models():
         return models
     except Exception as err:
         logs.log.error(f"Failed to retrieve Ollama model list: {err}")
-        return False
-
+        return []
 
 ###################################
 #


### PR DESCRIPTION
Issue: The interpreter used to throw error when ollama models where not found, this caused ollama_models state to be false causing the select box to crash in settings (Since not an Iterable).

Changes: return type of get_models() in catch statement gives an empty list. Also disables the select box when there no models and changes place holder to no models available.